### PR TITLE
Enhance limb replication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,10 @@ You are assisting in the modernization of the **rbx-wallstick** module — a wal
 ## 🧭 File Purposes
 
 ### `src/client/Wallstick/init.luau`
-- **Purpose**: Core Wallstick logic — binds surfaces, maintains state, handles player integration  
-- **Hooks into**: CharacterHelper, Replication  
-- **Notes**: Depends on `clientEntry.client.luau` for initialization  
+- **Purpose**: Core Wallstick logic — binds surfaces, maintains state, handles player integration
+- **Hooks into**: CharacterHelper, Replication
+- **Notes**: Depends on `clientEntry.client.luau` for initialization
+  - `_trySendReplication` now sends torso/head offsets for smoother remote animation
 
 ### `src/server/init.server.luau`
 - **Purpose**: Server bootstrap — sets up collision groups, player script overrides, replication listener  
@@ -69,6 +70,8 @@ You are assisting in the modernization of the **rbx-wallstick** module — a wal
 ### `src/client/Wallstick/Replication.luau`
 - **Purpose**: Network layer for syncing part offsets across clients and server
 - **Notes**: Uses TypedRemote for typed events
+  - Now replicates head and torso offsets in addition to root part
+  - Limb data throttled via `REPLICATE_DEBOUNCE_TIME`
 
 ### `src/client/clientEntry.client.luau`
 - **Purpose**: Client bootstrap; spawns Wallstick on character spawn and performs raycast checks
@@ -184,6 +187,10 @@ Ready for Codex reactivation and continued development.
 - Added File Purpose entry for `src/server/PlayerScripts/Animate/PlayEmote.model.json`
 - Assuming all character rigs include `RootAttachment`; unknown behavior otherwise
 - Possible refactor opportunity: unify replication debounce timing
+
+### [2025-07-21] Limb replication added
+- Replication module now broadcasts torso/head offsets
+- Wallstick `_trySendReplication` supplies limb data per player
 
 ---
 

--- a/src/client/Wallstick/Replication.luau
+++ b/src/client/Wallstick/Replication.luau
@@ -37,9 +37,12 @@ local TweenService = game:GetService("TweenService") :: TweenService
 local TypedRemote = require(game.ReplicatedStorage.SharedPackages.TypedRemote)
 local Replication = {}
 
+type LimbMap = { [string]: CFrame }
+
 type ReplicationFrame = {
 	part: BasePart,
 	offset: CFrame,
+	limbs: LimbMap?,
 }
 
 type ClientReplicationFrame = ReplicationFrame & {
@@ -49,14 +52,15 @@ type ClientReplicationFrame = ReplicationFrame & {
 }
 
 local syncRemote = TypedRemote.func("SyncRemote", script) :: TypedRemote.Function<(), ({ [Player]: ReplicationFrame })>
-local replicatorRemote = TypedRemote.event("ReplicatorRemote", script) :: TypedRemote.Event<BasePart?, CFrame?, Player?>
+local replicatorRemote =
+	TypedRemote.event("ReplicatorRemote", script) :: TypedRemote.Event<BasePart?, CFrame?, LimbMap?, Player?>
 Replication.ENABLED = true
 Replication.REPLICATE_DEBOUNCE_TIME = 0.2
 
-function Replication.send(part: BasePart, offset: CFrame)
+function Replication.send(part: BasePart, offset: CFrame, limbs: LimbMap?)
 	assert(RunService:IsClient(), "This API can only be called from the client.")
 	if Replication.ENABLED then
-		replicatorRemote:FireServer(part, offset)
+		replicatorRemote:FireServer(part, offset, limbs)
 	end
 end
 
@@ -74,17 +78,18 @@ function Replication.listenServer()
 		replicatorRemote:FireAllClients(nil, nil, player)
 	end)
 
-	replicatorRemote.OnServerEvent:Connect(function(player, part, offset)
+	replicatorRemote.OnServerEvent:Connect(function(player, part, offset, limbs)
 		if part and offset then
 			framesByPlayer[player] = {
 				part = part,
 				offset = offset,
+				limbs = limbs,
 			}
 		else
 			framesByPlayer[player] = nil
 		end
 
-		replicatorRemote:FireAllClients(part, offset, player)
+		replicatorRemote:FireAllClients(part, offset, limbs, player)
 	end)
 
 	syncRemote.OnServerInvoke = function(_player)
@@ -119,13 +124,14 @@ function Replication.listenClient()
 			clientFrameByPlayer[player] = {
 				part = frame.part,
 				offset = frame.offset,
+				limbs = frame.limbs,
 				fromOffset = frame.offset,
 				lerpOffset = frame.offset,
 				receivedAt = os.clock(),
 			}
 		end
 
-		replicatorRemote.OnClientEvent:Connect(function(part, offset, sentPlayer)
+		replicatorRemote.OnClientEvent:Connect(function(part, offset, limbs, sentPlayer)
 			local player = sentPlayer :: Player
 
 			if part and offset then
@@ -134,6 +140,7 @@ function Replication.listenClient()
 					or {
 						part = part,
 						offset = offset,
+						limbs = limbs,
 						fromOffset = offset,
 						lerpOffset = offset,
 						receivedAt = now,
@@ -145,6 +152,7 @@ function Replication.listenClient()
 				clientFrameByPlayer[player] = {
 					part = part,
 					offset = offset,
+					limbs = limbs,
 					fromOffset = fromOffset,
 					lerpOffset = fromOffset,
 					receivedAt = now,
@@ -175,9 +183,16 @@ function Replication.listenClient()
 
 				local targetCF = frame.part.CFrame * frame.lerpOffset
 
+				local limbOffsets = frame.limbs or {}
+
 				for _, part in parts do
 					if part:IsDescendantOf(character) then
-						part.CFrame = targetCF
+						local limbOffset = limbOffsets[part.Name]
+						if limbOffset then
+							part.CFrame = targetCF * limbOffset
+						else
+							part.CFrame = targetCF
+						end
 						part.Anchored = true
 					end
 				end

--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -275,7 +275,16 @@ function WallstickClass._trySendReplication(self: Wallstick, force: boolean)
 		local realRootCFrame = self:_getCalculatedRealRootCFrame()
 		local offset = self.part.CFrame:ToObjectSpace(realRootCFrame)
 
-		Replication.send(self.part, offset)
+		local root = self.real.rootPart
+		local limbs: { [string]: CFrame } = {}
+		for _, name in ipairs({ "Head", "Torso", "UpperTorso", "LowerTorso" }) do
+			local limb = self.real.character:FindFirstChild(name, true)
+			if limb and limb ~= root and limb:IsA("BasePart") then
+				limbs[name] = root.CFrame:ToObjectSpace((limb :: BasePart).CFrame)
+			end
+		end
+
+		Replication.send(self.part, offset, limbs)
 	end
 end
 


### PR DESCRIPTION
## Summary
- send torso and head offsets with Wallstick replication
- update replication system to handle limb data
- document replication changes in AGENTS notes

## Testing
- `stylua src/client/Wallstick/Replication.luau src/client/Wallstick/init.luau`

------
https://chatgpt.com/codex/tasks/task_e_687d790cad1883258325327f3fe27fe5