### PR TITLE
Implement WallstickCharacterState handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ You are assisting in the modernization of the **rbx-wallstick** module — a wal
 - **Hooks into**: CharacterHelper, Replication
 - **Notes**: Depends on `clientEntry.client.luau` for initialization
   - `_trySendReplication` now sends torso/head offsets for smoother remote animation
+  - Uses `CharacterHelper.setState()` to toggle `WallstickCharacterState`
 
 ### `src/server/init.server.luau`
 - **Purpose**: Server bootstrap — sets up collision groups, player script overrides, replication listener  
@@ -59,6 +60,8 @@ You are assisting in the modernization of the **rbx-wallstick** module — a wal
 ### `src/client/Wallstick/CharacterHelper.luau`
 - **Purpose**: Packages real and fake character models, applies alignment attachments
 - **Dependencies**: PlayerScripts, CharacterSoundsController
+- **Design Notes**: Now stores per-player `state` via `WallstickCharacterState` enum
+  table. Use `CharacterHelper.setState()` and `getState()` to update and query.
 
 ### `src/client/Wallstick/GravityCamera.luau`
 - **Purpose**: Wrapper API around PlayerModule camera with gravity-aware helpers
@@ -191,6 +194,12 @@ Ready for Codex reactivation and continued development.
 ### [2025-07-21] Limb replication added
 - Replication module now broadcasts torso/head offsets
 - Wallstick `_trySendReplication` supplies limb data per player
+
+### [2025-07-22] Character state tracking implemented
+- Added `WallstickCharacterState` enum in CharacterHelper
+- `characterData.state` now stores per-player state
+- Wallstick logic reacts to state during `_stepRenderCharacter` and `_stepPhysics`
+- Unknown states default to Freefall
 
 ---
 

--- a/src/client/Wallstick/CharacterHelper.luau
+++ b/src/client/Wallstick/CharacterHelper.luau
@@ -16,6 +16,18 @@ local STRIP_CLASSES: { [string]: boolean } = {
 	["Decal"] = true,
 }
 
+export type WallstickCharacterState = "Freefall" | "Anchored" | "Rebounding" | "Transitioning"
+
+-- Enum-like table describing wall-stick states
+local WallstickCharacterState = {
+	Freefall = "Freefall",
+	Anchored = "Anchored",
+	Rebounding = "Rebounding",
+	Transitioning = "Transitioning",
+}
+
+local characterDataByPlayer: { [Player]: { state: WallstickCharacterState } } = {}
+
 type BaseCharacter = {
 	character: Model,
 	rootPart: BasePart,
@@ -34,6 +46,31 @@ export type FakeCharacter = BaseCharacter & {
 local CharacterHelper = {}
 
 -- Private --
+
+function CharacterHelper.getData(player: Player)
+	local data = characterDataByPlayer[player]
+	if not data then
+		data = { state = WallstickCharacterState.Freefall }
+		characterDataByPlayer[player] = data
+	end
+	return data
+end
+
+function CharacterHelper.getState(player: Player): WallstickCharacterState
+	return CharacterHelper.getData(player).state
+end
+
+function CharacterHelper.setState(player: Player, newState: WallstickCharacterState?)
+	if not newState or not (WallstickCharacterState :: any)[newState] then
+		newState = WallstickCharacterState.Freefall
+	end
+
+	local data = CharacterHelper.getData(player)
+	if data.state ~= newState then
+		print(`[Wallstick] {player.Name} state: {data.state} -> {newState}`)
+		data.state = newState
+	end
+end
 
 local function getCharacter(player: Player): Model?
 	local character = player.Character
@@ -184,11 +221,13 @@ end
 -- Utility: prints all descendants of a character model for debugging purposes
 --[[
 function CharacterHelper.debug(character: Model)
-	print("Character Debug:", character:GetFullName())
-	for _, desc in character:GetDescendants() do
-		print(`[{desc.ClassName}] {desc:GetFullName()}`)
-	end
-end 
+        print("Character Debug:", character:GetFullName())
+        for _, desc in character:GetDescendants() do
+                print(`[{desc.ClassName}] {desc:GetFullName()}`)
+        end
+end
 ]]
+
+CharacterHelper.WallstickCharacterState = WallstickCharacterState
 
 return CharacterHelper

--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -46,6 +46,7 @@ local Replication = require(script.Replication)
 local GravityCamera = require(script.GravityCamera)
 local RotationSpring = require(script.RotationSpring)
 local CharacterHelper = require(script.CharacterHelper)
+local WallstickCharacterState = CharacterHelper.WallstickCharacterState
 
 local globalRenderTicket = 0
 
@@ -88,6 +89,8 @@ export type Wallstick = typeof(setmetatable(
 		fallStartHeight: number,
 		replicateTick: number,
 
+		state: CharacterHelper.WallstickCharacterState,
+
 		part: BasePart,
 		normal: Vector3,
 
@@ -112,6 +115,7 @@ function WallstickClass.new(options: Options): Wallstick
 	self.options = table.clone(options)
 	self.fallStartHeight = -1
 	self.replicateTick = -1
+	self.state = CharacterHelper.getState(Players.LocalPlayer)
 
 	self.part = workspace.Terrain
 	self.normal = Vector3.yAxis
@@ -180,6 +184,27 @@ function WallstickClass.new(options: Options): Wallstick
 end
 
 -- Private --
+
+function WallstickClass:_updateState(newState: WallstickCharacterState)
+	CharacterHelper.setState(Players.LocalPlayer, newState)
+	self.state = newState
+
+	if newState == WallstickCharacterState.Anchored then
+		for _, part in self.real.character:GetDescendants() do
+			if part:IsA("BasePart") then
+				part.Transparency = 1
+			end
+		end
+		self.fake.rootPart.Anchored = false
+	elseif newState == WallstickCharacterState.Freefall then
+		for _, part in self.real.character:GetDescendants() do
+			if part:IsA("BasePart") then
+				part.Transparency = 0
+			end
+		end
+		self.fake.rootPart.Anchored = true
+	end
+end
 
 local function fromToRotation(from: Vector3, to: Vector3, backupUnitAxis: Vector3?)
 	local dot = from:Dot(to)
@@ -300,6 +325,19 @@ function WallstickClass._stepRenderBeforeCamera(self: Wallstick, dt: number)
 end
 
 function WallstickClass._stepRenderCharacter(self: Wallstick, _dt: number)
+	local state = self.state or WallstickCharacterState.Freefall
+
+	if state == WallstickCharacterState.Freefall then
+		self.fake.rootPart.CFrame = self.real.rootPart.CFrame
+		self.fake.alignOrientation.Enabled = false
+		return
+	elseif state == WallstickCharacterState.Rebounding then
+		self.fake.rootPart.AssemblyLinearVelocity = Vector3.new(0, 20, 0)
+	elseif state == WallstickCharacterState.Transitioning then
+		local blended = self.real.rootPart.CFrame:Lerp(self.fake.rootPart.CFrame, 0.5)
+		self.fake.rootPart.CFrame = blended
+	end
+
 	local realRootCF = self:_getCalculatedRealRootCFrame()
 	local rootCameraOffset = realRootCF:ToObjectSpace(workspace.CurrentCamera.CFrame)
 	local geometryCameraCF = self.fake.rootPart.CFrame * rootCameraOffset
@@ -321,6 +359,16 @@ function WallstickClass._stepPhysics(self: Wallstick, _dt: number)
 	if self.fake.rootPart.Position.Y <= workspace.FallenPartsDestroyHeight then
 		self:Destroy()
 		return
+	end
+
+	local state = self.state or WallstickCharacterState.Freefall
+
+	if state == WallstickCharacterState.Freefall then
+		self.fake.rootPart.CFrame = self.real.rootPart.CFrame
+		self:_trySendReplication(false)
+		return
+	elseif state == WallstickCharacterState.Rebounding then
+		self.fake.rootPart.AssemblyLinearVelocity += Vector3.new(0, -1, 0)
 	end
 
 	local realRootCFrame = self:_getCalculatedRealRootCFrame()
@@ -396,6 +444,7 @@ function WallstickClass.set(self: Wallstick, part: BasePart, normal: Vector3, te
 
 	self.fallStartHeight = fakeRoot.Position.Y
 
+	self:_updateState(WallstickCharacterState.Anchored)
 	self:_updateCollisionGeometry()
 
 	if self.part ~= prevPart then
@@ -428,6 +477,7 @@ function WallstickClass.setAndTeleport(self: Wallstick, part: BasePart, normal: 
 end
 
 function WallstickClass.Destroy(self: Wallstick)
+	self:_updateState(WallstickCharacterState.Freefall)
 	self.trove:Destroy()
 end
 


### PR DESCRIPTION
## Summary
- add `WallstickCharacterState` enum and expose via CharacterHelper
- persist per-player state and helper APIs for setting/getting state
- drive wallstick behaviour based on current state
- export state table from CharacterHelper
- document new logic and behaviour in `AGENTS.md`

## Testing
- `stylua .`

------
https://chatgpt.com/codex/tasks/task_e_687d7c61563883259953303e5c2b92bb