### PR TITLE
Add WallstickCharacterState tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,5 +220,10 @@ Ready for Codex reactivation and continued development.
 - `isJumping` now toggles based solely on `StateChanged`
 - Logs new humanoid state for debugging
 
+### [2025-07-21] Velocity-based jump detection
+- State tracker now checks vertical velocity each Heartbeat
+- Detects jump start when Y speed > 2
+- Clears jump state once vertical speed falls to 0 or below
+
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,5 +206,9 @@ Ready for Codex reactivation and continued development.
 ### [2025-07-21] Debug state visibility
 - Heartbeat prints anchored/jumping flags when `DEBUG_STATE` is true
 
+### [2025-07-21] Jump state fix
+- Humanoid.Jumping now sets `isJumping` flag
+- Humanoid.StateChanged clears flag when leaving Jumping
+
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,5 +210,10 @@ Ready for Codex reactivation and continued development.
 - Humanoid.Jumping now sets `isJumping` flag
 - Humanoid.StateChanged clears flag when leaving Jumping
 
+### [2025-07-21] Jump debug improvements
+- Prints when root part anchored changes
+- Prints jump start and end with new state name
+- `Wallstick` confirms state tracker initialization
+
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ You are assisting in the modernization of the **rbx-wallstick** module — a wal
 - **Hooks into**: CharacterHelper, Replication
 - **Notes**: Depends on `clientEntry.client.luau` for initialization
   - `_trySendReplication` now sends torso/head offsets for smoother remote animation
+  - Integrates `WallstickCharacterState` for anchored/jumping flags
 
 ### `src/server/init.server.luau`
 - **Purpose**: Server bootstrap — sets up collision groups, player script overrides, replication listener  
@@ -72,6 +73,12 @@ You are assisting in the modernization of the **rbx-wallstick** module — a wal
 - **Notes**: Uses TypedRemote for typed events
   - Now replicates head and torso offsets in addition to root part
   - Limb data throttled via `REPLICATE_DEBOUNCE_TIME`
+
+### `src/client/Wallstick/WallstickCharacterState.luau`
+- **Purpose**: Tracks anchored and jumping flags for the local character
+- **Dependencies**: CharacterHelper, Trove
+- **Design**: Read-only `Get()` method; updates via property events
+- **Notes**: Uses capitalized method name to match user spec
 
 ### `src/client/clientEntry.client.luau`
 - **Purpose**: Client bootstrap; spawns Wallstick on character spawn and performs raycast checks
@@ -191,6 +198,10 @@ Ready for Codex reactivation and continued development.
 ### [2025-07-21] Limb replication added
 - Replication module now broadcasts torso/head offsets
 - Wallstick `_trySendReplication` supplies limb data per player
+
+### [2025-07-21] Character state module scaffolding
+- Added `WallstickCharacterState.luau` to track anchored and jumping state
+- Hooked module into `WallstickClass.new`
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,5 +203,8 @@ Ready for Codex reactivation and continued development.
 - Added `WallstickCharacterState.luau` to track anchored and jumping state
 - Hooked module into `WallstickClass.new`
 
+### [2025-07-21] Debug state visibility
+- Heartbeat prints anchored/jumping flags when `DEBUG_STATE` is true
+
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,5 +215,10 @@ Ready for Codex reactivation and continued development.
 - Prints jump start and end with new state name
 - `Wallstick` confirms state tracker initialization
 
+### [2025-07-21] Jump detection via StateChanged
+- Removed Humanoid.Jumping listener due to EvaluateStateMachine disabled
+- `isJumping` now toggles based solely on `StateChanged`
+- Logs new humanoid state for debugging
+
 ---
 

--- a/src/client/Wallstick/WallstickCharacterState.luau
+++ b/src/client/Wallstick/WallstickCharacterState.luau
@@ -51,17 +51,15 @@ function StateClass.new(trove: Trove.Trove, real: CharacterHelper.RealCharacter)
 		print("[StateTracker] Anchored changed:", real.rootPart.Anchored)
 	end))
 
-	self.trove:Add(real.humanoid.Jumping:Connect(function()
-		self.state.isJumping = true
-		print("[StateTracker] Jump START")
-	end))
-
 	self.trove:Add(real.humanoid.StateChanged:Connect(function(_, newState)
-		if newState ~= Enum.HumanoidStateType.Jumping then
-			if self.state.isJumping then
-				print("[StateTracker] Jump END \226\134\146 New State:", newState.Name)
-			end
-			self.state.isJumping = false
+		print("[Humanoid] New State:", newState.Name)
+
+		self.state.isJumping = newState == Enum.HumanoidStateType.Jumping
+
+		if self.state.isJumping then
+			print("[StateTracker] Jump START")
+		else
+			print("[StateTracker] Jump END → New State:", newState.Name)
 		end
 	end))
 

--- a/src/client/Wallstick/WallstickCharacterState.luau
+++ b/src/client/Wallstick/WallstickCharacterState.luau
@@ -13,6 +13,7 @@
           cleaned up via Trove by the creator.
 ]]
 
+local RunService = game:GetService("RunService")
 local Trove = require(game:GetService("ReplicatedStorage").SharedPackages.Trove)
 local CharacterHelper = require(script.Parent.CharacterHelper)
 
@@ -43,7 +44,7 @@ function StateClass.new(trove: Trove.Trove, real: CharacterHelper.RealCharacter)
 
 	self.state = {
 		isAnchored = real.rootPart.Anchored,
-		isJumping = real.humanoid:GetState() == Enum.HumanoidStateType.Jumping,
+		isJumping = false,
 	}
 
 	self.trove:Add(real.rootPart:GetPropertyChangedSignal("Anchored"):Connect(function()
@@ -51,15 +52,25 @@ function StateClass.new(trove: Trove.Trove, real: CharacterHelper.RealCharacter)
 		print("[StateTracker] Anchored changed:", real.rootPart.Anchored)
 	end))
 
-	self.trove:Add(real.humanoid.StateChanged:Connect(function(_, newState)
-		print("[Humanoid] New State:", newState.Name)
+	local lastY = real.rootPart.Position.Y
+	local isJumping = false
 
-		self.state.isJumping = newState == Enum.HumanoidStateType.Jumping
+	self.trove:Add(RunService.Heartbeat:Connect(function()
+		local velocity = real.rootPart.Velocity
+		local verticalSpeed = velocity.Y
 
-		if self.state.isJumping then
-			print("[StateTracker] Jump START")
-		else
-			print("[StateTracker] Jump END → New State:", newState.Name)
+		-- Detect jump by checking for sudden upward movement
+		if verticalSpeed > 2 and not isJumping then
+			isJumping = true
+			self.state.isJumping = true
+			print("[StateTracker] Jump START (Velocity Triggered)")
+		end
+
+		-- Reset jump once vertical speed drops or falls
+		if isJumping and verticalSpeed <= 0 then
+			isJumping = false
+			self.state.isJumping = false
+			print("[StateTracker] Jump END (Velocity Dropped)")
 		end
 	end))
 

--- a/src/client/Wallstick/WallstickCharacterState.luau
+++ b/src/client/Wallstick/WallstickCharacterState.luau
@@ -1,0 +1,60 @@
+--!strict
+--[[
+        @module WallstickCharacterState
+
+        Simple state tracker for wall-sticking characters. Currently exposes
+        read-only flags for whether the real character's root part is anchored
+        and whether the humanoid is in the Jumping state.
+
+        Design Notes:
+        - Only provides Get() method per user request. Future work may expose
+          mutators or additional flags.
+        - Uses direct property change connections on the real character and is
+          cleaned up via Trove by the creator.
+]]
+
+local Trove = require(game:GetService("ReplicatedStorage").SharedPackages.Trove)
+local CharacterHelper = require(script.Parent.CharacterHelper)
+
+-- Class --
+local StateClass = {}
+StateClass.__index = StateClass
+StateClass.ClassName = "WallstickCharacterState"
+
+export type Flags = {
+	isAnchored: boolean,
+	isJumping: boolean,
+}
+
+export type WallstickCharacterState = typeof(setmetatable({}, StateClass)) & {
+	trove: Trove.Trove,
+	real: CharacterHelper.RealCharacter,
+	flags: Flags,
+}
+
+function StateClass.new(trove: Trove.Trove, real: CharacterHelper.RealCharacter): WallstickCharacterState
+	local self = setmetatable({}, StateClass) :: WallstickCharacterState
+
+	self.trove = trove
+	self.real = real
+	self.flags = {
+		isAnchored = real.rootPart.Anchored,
+		isJumping = real.humanoid:GetState() == Enum.HumanoidStateType.Jumping,
+	}
+
+	self.trove:Add(real.rootPart:GetPropertyChangedSignal("Anchored"):Connect(function()
+		self.flags.isAnchored = real.rootPart.Anchored
+	end))
+
+	self.trove:Add(real.humanoid.StateChanged:Connect(function(_, newState)
+		self.flags.isJumping = newState == Enum.HumanoidStateType.Jumping
+	end))
+
+	return self
+end
+
+function StateClass.Get(self: WallstickCharacterState): Flags
+	return table.clone(self.flags)
+end
+
+return StateClass

--- a/src/client/Wallstick/WallstickCharacterState.luau
+++ b/src/client/Wallstick/WallstickCharacterState.luau
@@ -46,8 +46,14 @@ function StateClass.new(trove: Trove.Trove, real: CharacterHelper.RealCharacter)
 		self.flags.isAnchored = real.rootPart.Anchored
 	end))
 
+	self.trove:Add(real.humanoid.Jumping:Connect(function()
+		self.flags.isJumping = true
+	end))
+
 	self.trove:Add(real.humanoid.StateChanged:Connect(function(_, newState)
-		self.flags.isJumping = newState == Enum.HumanoidStateType.Jumping
+		if newState ~= Enum.HumanoidStateType.Jumping then
+			self.flags.isJumping = false
+		end
 	end))
 
 	return self

--- a/src/client/Wallstick/WallstickCharacterState.luau
+++ b/src/client/Wallstick/WallstickCharacterState.luau
@@ -2,13 +2,13 @@
 --[[
         @module WallstickCharacterState
 
-        Simple state tracker for wall-sticking characters. Currently exposes
-        read-only flags for whether the real character's root part is anchored
-        and whether the humanoid is in the Jumping state.
+       Simple state tracker for wall-sticking characters. Currently exposes
+       read-only state for whether the real character's root part is anchored
+       and whether the humanoid is in the Jumping state.
 
         Design Notes:
-        - Only provides Get() method per user request. Future work may expose
-          mutators or additional flags.
+       - Only provides Get() method per user request. Future work may expose
+         mutators or additional state fields.
         - Uses direct property change connections on the real character and is
           cleaned up via Trove by the creator.
 ]]
@@ -21,7 +21,7 @@ local StateClass = {}
 StateClass.__index = StateClass
 StateClass.ClassName = "WallstickCharacterState"
 
-export type Flags = {
+export type State = {
 	isAnchored: boolean,
 	isJumping: boolean,
 }
@@ -29,7 +29,7 @@ export type Flags = {
 export type WallstickCharacterState = typeof(setmetatable({}, StateClass)) & {
 	trove: Trove.Trove,
 	real: CharacterHelper.RealCharacter,
-	flags: Flags,
+	state: State,
 }
 
 function StateClass.new(trove: Trove.Trove, real: CharacterHelper.RealCharacter): WallstickCharacterState
@@ -37,30 +37,39 @@ function StateClass.new(trove: Trove.Trove, real: CharacterHelper.RealCharacter)
 
 	self.trove = trove
 	self.real = real
-	self.flags = {
+
+	assert(real.humanoid:IsA("Humanoid"), "Invalid Humanoid")
+	assert(real.rootPart:IsA("BasePart"), "Invalid RootPart")
+
+	self.state = {
 		isAnchored = real.rootPart.Anchored,
 		isJumping = real.humanoid:GetState() == Enum.HumanoidStateType.Jumping,
 	}
 
 	self.trove:Add(real.rootPart:GetPropertyChangedSignal("Anchored"):Connect(function()
-		self.flags.isAnchored = real.rootPart.Anchored
+		self.state.isAnchored = real.rootPart.Anchored
+		print("[StateTracker] Anchored changed:", real.rootPart.Anchored)
 	end))
 
 	self.trove:Add(real.humanoid.Jumping:Connect(function()
-		self.flags.isJumping = true
+		self.state.isJumping = true
+		print("[StateTracker] Jump START")
 	end))
 
 	self.trove:Add(real.humanoid.StateChanged:Connect(function(_, newState)
 		if newState ~= Enum.HumanoidStateType.Jumping then
-			self.flags.isJumping = false
+			if self.state.isJumping then
+				print("[StateTracker] Jump END \226\134\146 New State:", newState.Name)
+			end
+			self.state.isJumping = false
 		end
 	end))
 
 	return self
 end
 
-function StateClass.Get(self: WallstickCharacterState): Flags
-	return table.clone(self.flags)
+function StateClass.Get(self: WallstickCharacterState): State
+	return table.clone(self.state)
 end
 
 return StateClass

--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -131,6 +131,7 @@ function WallstickClass.new(options: Options): Wallstick
 	self.real = CharacterHelper.real(Players.LocalPlayer)
 	self.fake = CharacterHelper.fake(Players.LocalPlayer)
 	self.stateTracker = WallstickCharacterState.new(self.trove, self.real)
+	print("[Wallstick] Initialized state tracker")
 
 	if DEBUG_STATE then
 		self.trove:Add(RunService.Heartbeat:Connect(function()

--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -49,6 +49,7 @@ local CharacterHelper = require(script.CharacterHelper)
 local WallstickCharacterState = require(script.WallstickCharacterState)
 
 local globalRenderTicket = 0
+local DEBUG_STATE = true
 
 local CLASS_NAMES_TO_CONVERT = {
 	["Seat"] = { ClassName = "Part" },
@@ -99,7 +100,7 @@ export type Wallstick = typeof(setmetatable(
 
 		real: CharacterHelper.RealCharacter,
 		fake: CharacterHelper.FakeCharacter,
-		state: WallstickCharacterState.WallstickCharacterState,
+		stateTracker: WallstickCharacterState.WallstickCharacterState,
 	},
 	WallstickClass
 ))
@@ -129,7 +130,16 @@ function WallstickClass.new(options: Options): Wallstick
 
 	self.real = CharacterHelper.real(Players.LocalPlayer)
 	self.fake = CharacterHelper.fake(Players.LocalPlayer)
-	self.state = WallstickCharacterState.new(self.trove, self.real)
+	self.stateTracker = WallstickCharacterState.new(self.trove, self.real)
+
+	if DEBUG_STATE then
+		self.trove:Add(RunService.Heartbeat:Connect(function()
+			if self.stateTracker then
+				local state = self.stateTracker:Get()
+				print("[Wallstick State] Anchored:", state.isAnchored, "| Jumping:", state.isJumping)
+			end
+		end))
+	end
 
 	self.trove:Add(CharacterHelper.applyCollisionGroup(self.real.character, "WallstickNoCollision"))
 

--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -46,6 +46,7 @@ local Replication = require(script.Replication)
 local GravityCamera = require(script.GravityCamera)
 local RotationSpring = require(script.RotationSpring)
 local CharacterHelper = require(script.CharacterHelper)
+local WallstickCharacterState = require(script.WallstickCharacterState)
 
 local globalRenderTicket = 0
 
@@ -98,6 +99,7 @@ export type Wallstick = typeof(setmetatable(
 
 		real: CharacterHelper.RealCharacter,
 		fake: CharacterHelper.FakeCharacter,
+		state: WallstickCharacterState.WallstickCharacterState,
 	},
 	WallstickClass
 ))
@@ -127,6 +129,7 @@ function WallstickClass.new(options: Options): Wallstick
 
 	self.real = CharacterHelper.real(Players.LocalPlayer)
 	self.fake = CharacterHelper.fake(Players.LocalPlayer)
+	self.state = WallstickCharacterState.new(self.trove, self.real)
 
 	self.trove:Add(CharacterHelper.applyCollisionGroup(self.real.character, "WallstickNoCollision"))
 


### PR DESCRIPTION
## Summary
- track anchored/jumping flags with `WallstickCharacterState` module
- integrate state tracker into `WallstickClass.new`
- document new module and usage in AGENTS.md

## Testing
- `stylua src`

------
https://chatgpt.com/codex/tasks/task_e_687de82e178483259a04d294c0ce717b