### PR TITLE
Add shared CFrame utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,10 @@ You are assisting in the modernization of the **rbx-wallstick** module — a wal
   - Now replicates head and torso offsets in addition to root part
   - Limb data throttled via `REPLICATE_DEBOUNCE_TIME`
 
+### `src/shared/CFrameUtils.luau`
+- **Purpose**: Shared math helpers providing `fromToRotation()` and `swingTwist()`
+  for quaternion conversions used by Wallstick and GravityCameraModifier
+
 ### `src/client/clientEntry.client.luau`
 - **Purpose**: Client bootstrap; spawns Wallstick on character spawn and performs raycast checks
 ### `src/server/PlayerScripts/init.luau`

--- a/default.project.json
+++ b/default.project.json
@@ -2,16 +2,19 @@
 	"name": "rbx-wallstick",
 	"tree": {
 		"$className": "DataModel",
-		"ReplicatedStorage": {
-			"$className": "ReplicatedStorage",
-			"Wallstick": {
-				"$path": "src/client/Wallstick"
-			},
-			"SharedPackages": {
-				"$path": {
-					"optional": "Packages"
-				}
-			}
+                "ReplicatedStorage": {
+                        "$className": "ReplicatedStorage",
+                        "Wallstick": {
+                                "$path": "src/client/Wallstick"
+                        },
+                        "CFrameUtils": {
+                                "$path": "src/shared/CFrameUtils.luau"
+                        },
+                        "SharedPackages": {
+                                "$path": {
+                                        "optional": "Packages"
+                                }
+                        }
 		},
 		"ServerScriptService": {
 			"$className": "ServerScriptService",

--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -40,6 +40,7 @@ local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local SharedPackages = ReplicatedStorage.SharedPackages
+local CFrameUtils = require(ReplicatedStorage:WaitForChild("CFrameUtils"))
 local Trove = require(SharedPackages.Trove)
 
 local Replication = require(script.Replication)
@@ -178,23 +179,10 @@ function WallstickClass.new(options: Options): Wallstick
 
 	return self
 end
-
 -- Private --
 
-local function fromToRotation(from: Vector3, to: Vector3, backupUnitAxis: Vector3?)
-	local dot = from:Dot(to)
-	if dot < -0.99999 then
-		return if backupUnitAxis
-			then CFrame.fromAxisAngle(backupUnitAxis, math.pi)
-			else CFrame.fromRotationBetweenVectors(from, to)
-	end
-	local qv = from:Cross(to)
-	local qw = math.sqrt(from:Dot(from) * to:Dot(to)) + dot
-	return CFrame.new(0, 0, 0, qv.X, qv.Y, qv.Z, qw)
-end
-
 function WallstickClass._getOriginCFrame(self: Wallstick)
-	return self.options.origin * fromToRotation(self.normal, Vector3.yAxis, Vector3.xAxis)
+	return self.options.origin * CFrameUtils.fromToRotation(self.normal, Vector3.yAxis, Vector3.xAxis)
 end
 
 function WallstickClass._getCalculatedRealRootCFrame(self: Wallstick)
@@ -361,7 +349,7 @@ function WallstickClass.set(self: Wallstick, part: BasePart, normal: Vector3, te
 
 	local partCF = part.CFrame
 	local newWorldNormal = partCF:VectorToWorldSpace(normal)
-	local worldGoalUpCFrame = fromToRotation(worldUpCFrame.YVector, newWorldNormal, worldUpCFrame.XVector)
+	local worldGoalUpCFrame = CFrameUtils.fromToRotation(worldUpCFrame.YVector, newWorldNormal, worldUpCFrame.XVector)
 		* worldUpCFrame
 
 	self.cameraUpSpring:setGoal(partCF:ToObjectSpace(worldGoalUpCFrame))
@@ -377,7 +365,7 @@ function WallstickClass.set(self: Wallstick, part: BasePart, normal: Vector3, te
 
 	local originCF = self:_getOriginCFrame()
 	local targetCF = originCF * self.part.CFrame:ToObjectSpace(teleportCF or self.real.rootPart.CFrame)
-	local sphericalArc = fromToRotation(targetCF.YVector, Vector3.yAxis, targetCF.XVector)
+	local sphericalArc = CFrameUtils.fromToRotation(targetCF.YVector, Vector3.yAxis, targetCF.XVector)
 	local resultCF = (sphericalArc * targetCF.Rotation) + targetCF.Position
 
 	local fakeRoot = self.fake.rootPart
@@ -409,7 +397,8 @@ function WallstickClass.setAndPivot(self: Wallstick, part: BasePart, normal: Vec
 	local heightAdjust = (realRootCF.Position - position):Dot(worldNormal)
 
 	local floorRootCF = realRootCF * CFrame.new(0, -heightAdjust, 0)
-	local newRotation = fromToRotation(floorRootCF.YVector, worldNormal, floorRootCF.XVector) * floorRootCF.Rotation
+	local newRotation = CFrameUtils.fromToRotation(floorRootCF.YVector, worldNormal, floorRootCF.XVector)
+		* floorRootCF.Rotation
 	local teleportCF = CFrame.new(position) * newRotation * CFrame.new(0, heightAdjust, 0)
 
 	return self:set(part, normal, teleportCF)
@@ -421,7 +410,8 @@ function WallstickClass.setAndTeleport(self: Wallstick, part: BasePart, normal: 
 	local heightAdjust = self.real.rootPart.Size.Y / 2 + self.real.humanoid.HipHeight
 
 	local floorRootCF = realRootCF * CFrame.new(0, -heightAdjust, 0)
-	local newRotation = fromToRotation(floorRootCF.YVector, worldNormal, floorRootCF.XVector) * floorRootCF.Rotation
+	local newRotation = CFrameUtils.fromToRotation(floorRootCF.YVector, worldNormal, floorRootCF.XVector)
+		* floorRootCF.Rotation
 	local teleportCF = CFrame.new(position) * newRotation * CFrame.new(0, heightAdjust, 0)
 
 	return self:set(part, normal, teleportCF)

--- a/src/server/PlayerScripts/GravityCameraModifier.luau
+++ b/src/server/PlayerScripts/GravityCameraModifier.luau
@@ -19,7 +19,9 @@
 	- Uses `CameraUtils` for angle math, rotation type override, and input locking
 ]]
 
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserGameSettings = UserSettings():GetService("UserGameSettings")
+local CFrameUtils = require(ReplicatedStorage:WaitForChild("CFrameUtils"))
 
 local GravityState = {
 	transitionRate = 1,
@@ -33,29 +35,6 @@ local GravityState = {
 }
 
 -- Utility (math support)
-local function fromToRotation(from: Vector3, to: Vector3, backupUnitAxis: Vector3?)
-	local dot = from:Dot(to)
-	if dot < -0.99999 then
-		return if backupUnitAxis
-			then CFrame.fromAxisAngle(backupUnitAxis, math.pi)
-			else CFrame.fromRotationBetweenVectors(from, to)
-	end
-	local qv = from:Cross(to)
-	local qw = math.sqrt(from:Dot(from) * to:Dot(to)) + dot
-	return CFrame.new(0, 0, 0, qv.X, qv.Y, qv.Z, qw)
-end
-
-local function swingTwist(inputCF: CFrame, relativeUnitAxis: Vector3)
-	local axis, theta = inputCF:ToAxisAngle()
-	local w, v = math.cos(theta / 2), math.sin(theta / 2) * axis
-
-	local proj = v:Dot(relativeUnitAxis) * relativeUnitAxis
-	local twist = CFrame.new(0, 0, 0, proj.X, proj.Y, proj.Z, w)
-
-	local swing = inputCF * twist:Inverse()
-
-	return swing, twist
-end
 
 -- Gravity core (internal logic)
 local function calculateUpStep(_dt: number)
@@ -64,7 +43,7 @@ local function calculateUpStep(_dt: number)
 	end
 	local axis = workspace.CurrentCamera.CFrame.RightVector
 
-	local sphericalArc = fromToRotation(GravityState.upVector, GravityState.targetUpVector, axis)
+	local sphericalArc = CFrameUtils.fromToRotation(GravityState.upVector, GravityState.targetUpVector, axis)
 	local transitionCF = CFrame.new():Lerp(sphericalArc, GravityState.transitionRate)
 
 	GravityState.upVector = transitionCF * GravityState.upVector
@@ -83,7 +62,7 @@ local function calculateSpinStep(_dt: number, inVehicle: boolean)
 		local delta = prevRotation:ToObjectSpace(rotation)
 		local spinAxis = delta:VectorToObjectSpace(prevRotation:VectorToObjectSpace(GravityState.upVector))
 
-		local _swing, twist = swingTwist(delta, spinAxis)
+		local _swing, twist = CFrameUtils.swingTwist(delta, spinAxis)
 		local deltaAxis, _deltaTheta = delta:ToAxisAngle()
 		local _twistAxis, twistTheta = twist:ToAxisAngle()
 

--- a/src/shared/CFrameUtils.luau
+++ b/src/shared/CFrameUtils.luau
@@ -1,0 +1,47 @@
+--!strict
+--[[
+    @module CFrameUtils
+    Utility functions for quaternion-based CFrame math.
+    Provides fromToRotation() and swingTwist() for aligning axes and
+    decomposing rotations. Shared by Wallstick and GravityCameraModifier.
+]]
+
+local CFrameUtils = {}
+
+--[=[
+    Calculates the rotation CFrame that aligns one unit vector with another.
+    Falls back to CFrame.fromAxisAngle when vectors are opposite to avoid
+    gimbal lock. Inspired by the "Aligning CFrames" article on the
+    Roblox Creator Hub.
+]=]
+function CFrameUtils.fromToRotation(from: Vector3, to: Vector3, backupUnitAxis: Vector3?): CFrame
+	local dot = from:Dot(to)
+	if dot < -0.99999 then
+		return if backupUnitAxis
+			then CFrame.fromAxisAngle(backupUnitAxis, math.pi)
+			else CFrame.fromRotationBetweenVectors(from, to)
+	end
+	local qv = from:Cross(to)
+	local qw = math.sqrt(from:Dot(from) * to:Dot(to)) + dot
+	return CFrame.new(0, 0, 0, qv.X, qv.Y, qv.Z, qw)
+end
+
+--[=[
+    Splits a rotation into swing and twist components relative to a given axis.
+    Useful for isolating roll around an axis. Based on standard quaternion
+    decomposition techniques.
+]=]
+function CFrameUtils.swingTwist(inputCF: CFrame, relativeUnitAxis: Vector3): (CFrame, CFrame)
+	local axis, theta = inputCF:ToAxisAngle()
+	local w = math.cos(theta / 2)
+	local v = math.sin(theta / 2) * axis
+
+	local proj = v:Dot(relativeUnitAxis) * relativeUnitAxis
+	local twist = CFrame.new(0, 0, 0, proj.X, proj.Y, proj.Z, w)
+
+	local swing = inputCF * twist:Inverse()
+
+	return swing, twist
+end
+
+return CFrameUtils


### PR DESCRIPTION
## Summary
- add `CFrameUtils` module for quaternion helpers
- use the new utilities in `Wallstick` and `GravityCameraModifier`
- expose `CFrameUtils` from ReplicatedStorage via Rojo config
- document the module in `AGENTS.md`

## Testing
- `stylua .`

------
https://chatgpt.com/codex/tasks/task_e_687eba33705883259908764c45781f25