### PR TITLE
Add debug arrow utility with TTL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,13 @@ You are assisting in the modernization of the **rbx-wallstick** module — a wal
 - **Purpose**: Shared math helpers providing `fromToRotation()` and `swingTwist()`
   for quaternion conversions used by Wallstick and GravityCameraModifier
 
+### `src/client/Wallstick/Debug/GravityVisualizer.luau`
+- **Purpose**: Studio-only helper drawing arrows for current and target up vectors
+- **Notes**: Requires `_G.WALLSTICK_DEBUG` and does not replicate adornments
+
+### `src/client/Wallstick/Debug/DebugDraw.luau`
+- **Purpose**: Utility for spawning ArrowHandleAdornments with ZIndex and TTL support
+
 ### `src/client/clientEntry.client.luau`
 - **Purpose**: Client bootstrap; spawns Wallstick on character spawn and performs raycast checks
 ### `src/server/PlayerScripts/init.luau`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ You are assisting in the modernization of the **rbx-wallstick** module — a wal
 
 ### `src/client/Wallstick/Debug/DebugDraw.luau`
 - **Purpose**: Utility for spawning ArrowHandleAdornments with ZIndex and TTL support
+- **Notes**: `arrow(adorneePart, localCFrame)` requires a BasePart and attaches to the nearest planet when using `arrowFromVector`
 
 ### `src/client/clientEntry.client.luau`
 - **Purpose**: Client bootstrap; spawns Wallstick on character spawn and performs raycast checks

--- a/src/client/Wallstick/Debug/DebugDraw.luau
+++ b/src/client/Wallstick/Debug/DebugDraw.luau
@@ -15,15 +15,15 @@ local nextZIndex = 0
 local DebugDraw = {}
 
 --[[
-    Draws an arrow at the given world CFrame.
-    @param parent Instance to parent the adornment to (e.g. workspace.CurrentCamera)
-    @param cframe World-space CFrame for the arrow's origin and direction
+    Draws an arrow relative to the given adornee part.
+    @param adorneePart BasePart that the adornment attaches to
+    @param localCFrame CFrame relative to the part for the arrow's origin and direction
     @param color Color3 of the arrow
     @param length Optional length; defaults to 1
     @param timeToLive Optional seconds before automatic removal
     @return ArrowHandleAdornment?
 ]]
-function DebugDraw.arrow(parent: Instance, cframe: CFrame, color: Color3, length: number?, timeToLive: number?)
+function DebugDraw.arrow(adorneePart: BasePart, localCFrame: CFrame, color: Color3, length: number?, timeToLive: number?)
     if not RunService:IsStudio() then
         return nil
     end
@@ -38,11 +38,16 @@ function DebugDraw.arrow(parent: Instance, cframe: CFrame, color: Color3, length
     arrow.Length = length or 1
     arrow.ZIndex = index
 
+    local offsetVec = Vector3.zero
     local camera = Workspace.CurrentCamera
-    local offset = camera and camera.CFrame.RightVector * OFFSET_STEP * index or Vector3.zero
-    arrow.CFrame = cframe + offset
+    if camera then
+        local worldOffset = camera.CFrame.RightVector * OFFSET_STEP * index
+        offsetVec = adorneePart.CFrame:VectorToObjectSpace(worldOffset)
+    end
 
-    arrow.Parent = parent
+    arrow.CFrame = localCFrame + offsetVec
+    arrow.Adornee = adorneePart
+    arrow.Parent = adorneePart
 
     if timeToLive then
         Debris:AddItem(arrow, timeToLive)
@@ -53,6 +58,7 @@ end
 
 --[[
     Draws an arrow from an origin and direction vector.
+    Automatically attaches to the closest planet in `workspace.Planets`.
     @param origin World position
     @param direction Vector pointing toward arrow end
     @param color Color of the arrow
@@ -64,9 +70,30 @@ function DebugDraw.arrowFromVector(origin: Vector3, direction: Vector3, color: C
     if direction.Magnitude == 0 then
         return nil
     end
+
+    local planetsFolder = Workspace:FindFirstChild("Planets")
+    local closestPart: BasePart? = nil
+    local closestDist = math.huge
+    if planetsFolder then
+        for _, obj in ipairs(planetsFolder:GetChildren()) do
+            if obj:IsA("BasePart") then
+                local dist = (obj.Position - origin).Magnitude
+                if dist < closestDist then
+                    closestDist = dist
+                    closestPart = obj
+                end
+            end
+        end
+    end
+    if not closestPart then
+        return nil
+    end
+
     local len = direction.Magnitude * (scale or 1)
-    local cf = CFrame.lookAt(origin, origin + direction)
-    return DebugDraw.arrow(Workspace.CurrentCamera, cf, color, len, timeToLive)
+    local worldCF = CFrame.lookAt(origin, origin + direction)
+    local localCF = closestPart.CFrame:ToObjectSpace(worldCF)
+
+    return DebugDraw.arrow(closestPart, localCF, color, len, timeToLive)
 end
 
 return DebugDraw

--- a/src/client/Wallstick/Debug/DebugDraw.luau
+++ b/src/client/Wallstick/Debug/DebugDraw.luau
@@ -1,0 +1,72 @@
+--!strict
+--[[
+    @class DebugDraw
+    Utility helpers for visualizing vectors in Studio using ArrowHandleAdornment.
+    Arrows respect ZIndex ordering and can auto-cleanup after a time to live.
+]]
+
+local RunService = game:GetService("RunService")
+local Debris = game:GetService("Debris")
+local Workspace = game:GetService("Workspace")
+
+local OFFSET_STEP = 0.05
+local nextZIndex = 0
+
+local DebugDraw = {}
+
+--[[
+    Draws an arrow at the given world CFrame.
+    @param parent Instance to parent the adornment to (e.g. workspace.CurrentCamera)
+    @param cframe World-space CFrame for the arrow's origin and direction
+    @param color Color3 of the arrow
+    @param length Optional length; defaults to 1
+    @param timeToLive Optional seconds before automatic removal
+    @return ArrowHandleAdornment?
+]]
+function DebugDraw.arrow(parent: Instance, cframe: CFrame, color: Color3, length: number?, timeToLive: number?)
+    if not RunService:IsStudio() then
+        return nil
+    end
+
+    local index = nextZIndex
+    nextZIndex += 1
+
+    local arrow = Instance.new("ArrowHandleAdornment")
+    arrow.AlwaysOnTop = true
+    arrow.Thickness = 0.1
+    arrow.Color3 = color
+    arrow.Length = length or 1
+    arrow.ZIndex = index
+
+    local camera = Workspace.CurrentCamera
+    local offset = camera and camera.CFrame.RightVector * OFFSET_STEP * index or Vector3.zero
+    arrow.CFrame = cframe + offset
+
+    arrow.Parent = parent
+
+    if timeToLive then
+        Debris:AddItem(arrow, timeToLive)
+    end
+
+    return arrow
+end
+
+--[[
+    Draws an arrow from an origin and direction vector.
+    @param origin World position
+    @param direction Vector pointing toward arrow end
+    @param color Color of the arrow
+    @param scale Optional scale multiplier for direction length (default 1)
+    @param timeToLive Optional seconds before automatic removal
+    @return ArrowHandleAdornment?
+]]
+function DebugDraw.arrowFromVector(origin: Vector3, direction: Vector3, color: Color3, scale: number?, timeToLive: number?)
+    if direction.Magnitude == 0 then
+        return nil
+    end
+    local len = direction.Magnitude * (scale or 1)
+    local cf = CFrame.lookAt(origin, origin + direction)
+    return DebugDraw.arrow(Workspace.CurrentCamera, cf, color, len, timeToLive)
+end
+
+return DebugDraw

--- a/src/client/Wallstick/Debug/GravityVisualizer.luau
+++ b/src/client/Wallstick/Debug/GravityVisualizer.luau
@@ -1,0 +1,98 @@
+--!strict
+--[[
+        @class GravityVisualizer
+        Studio-only helper that visualizes current and target up vectors on the local player.
+        Draws green and red arrows from the HumanoidRootPart.
+        Toggle with global `_G.WALLSTICK_DEBUG`.
+]]
+
+local RunService = game:GetService("RunService")
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local GravityCamera = require(ReplicatedStorage:WaitForChild("Wallstick"):WaitForChild("GravityCamera"))
+local Trove = require(ReplicatedStorage:WaitForChild("SharedPackages"):WaitForChild("Trove"))
+local DebugDraw = require(ReplicatedStorage:WaitForChild("Wallstick"):WaitForChild("Debug"):WaitForChild("DebugDraw"))
+
+local LENGTH = 4
+
+local GravityVisualizer = {}
+GravityVisualizer.__index = GravityVisualizer
+
+function GravityVisualizer.new()
+	if not RunService:IsStudio() then
+		return nil
+	end
+	if not (_G.WALLSTICK_DEBUG == true) then
+		return nil
+	end
+
+	local self = setmetatable({}, GravityVisualizer)
+	self._trove = Trove.new()
+
+	local player = Players.LocalPlayer
+	local character = player.Character or player.CharacterAdded:Wait()
+	local root = character:WaitForChild("HumanoidRootPart") :: BasePart
+	self._root = root
+
+       local currentArrow = DebugDraw.arrow(workspace.CurrentCamera, CFrame.identity, Color3.fromRGB(0, 255, 0), LENGTH)
+       if currentArrow then
+               currentArrow.Name = "CurrentUpVector"
+               currentArrow.Adornee = root
+               self._trove:Add(currentArrow)
+               self._currentArrow = currentArrow
+       end
+
+       local targetArrow = DebugDraw.arrow(workspace.CurrentCamera, CFrame.identity, Color3.fromRGB(255, 0, 0), LENGTH)
+       if targetArrow then
+               targetArrow.Name = "TargetUpVector"
+               targetArrow.Adornee = root
+               self._trove:Add(targetArrow)
+               self._targetArrow = targetArrow
+       end
+
+	local gui = Instance.new("BillboardGui")
+	gui.Name = "GravityInfo"
+	gui.Size = UDim2.fromOffset(120, 40)
+	gui.StudsOffsetWorldSpace = Vector3.new(0, 4, 0)
+	gui.AlwaysOnTop = true
+	gui.Adornee = root
+	gui.Parent = workspace.CurrentCamera
+	self._trove:Add(gui)
+
+	local label = Instance.new("TextLabel")
+	label.Size = UDim2.fromScale(1, 1)
+	label.BackgroundTransparency = 1
+	label.TextColor3 = Color3.new(1, 1, 1)
+	label.TextScaled = true
+	label.Font = Enum.Font.SourceSans
+	label.Parent = gui
+	self._label = label
+
+	self._trove:Add(RunService.RenderStepped:Connect(function()
+		self:_update()
+	end))
+
+	return self
+end
+
+function GravityVisualizer:_update()
+	local origin = self._root.Position
+	local upVector = GravityCamera.getUpVector()
+	local targetVector = GravityCamera.getTargetUpVector()
+
+	self._currentArrow.CFrame = CFrame.lookAt(origin, origin + upVector)
+	self._currentArrow.Length = LENGTH
+
+	self._targetArrow.CFrame = CFrame.lookAt(origin, origin + targetVector)
+	self._targetArrow.Length = LENGTH
+
+	local angle = math.deg(math.acos(math.clamp(upVector:Dot(targetVector), -1, 1)))
+	self._label.Text = string.format("|u| %.2f\n\u2220 %.2f", upVector.Magnitude, angle)
+end
+
+function GravityVisualizer:Destroy()
+	self._trove:Destroy()
+end
+
+return GravityVisualizer

--- a/src/client/Wallstick/Debug/GravityVisualizer.luau
+++ b/src/client/Wallstick/Debug/GravityVisualizer.luau
@@ -35,18 +35,16 @@ function GravityVisualizer.new()
 	local root = character:WaitForChild("HumanoidRootPart") :: BasePart
 	self._root = root
 
-       local currentArrow = DebugDraw.arrow(workspace.CurrentCamera, CFrame.identity, Color3.fromRGB(0, 255, 0), LENGTH)
+       local currentArrow = DebugDraw.arrow(root, CFrame.identity, Color3.fromRGB(0, 255, 0), LENGTH)
        if currentArrow then
                currentArrow.Name = "CurrentUpVector"
-               currentArrow.Adornee = root
                self._trove:Add(currentArrow)
                self._currentArrow = currentArrow
        end
 
-       local targetArrow = DebugDraw.arrow(workspace.CurrentCamera, CFrame.identity, Color3.fromRGB(255, 0, 0), LENGTH)
+       local targetArrow = DebugDraw.arrow(root, CFrame.identity, Color3.fromRGB(255, 0, 0), LENGTH)
        if targetArrow then
                targetArrow.Name = "TargetUpVector"
-               targetArrow.Adornee = root
                self._trove:Add(targetArrow)
                self._targetArrow = targetArrow
        end
@@ -81,11 +79,13 @@ function GravityVisualizer:_update()
 	local upVector = GravityCamera.getUpVector()
 	local targetVector = GravityCamera.getTargetUpVector()
 
-	self._currentArrow.CFrame = CFrame.lookAt(origin, origin + upVector)
-	self._currentArrow.Length = LENGTH
+        local worldCurrentCF = CFrame.lookAt(origin, origin + upVector)
+        self._currentArrow.CFrame = self._root.CFrame:ToObjectSpace(worldCurrentCF)
+        self._currentArrow.Length = LENGTH
 
-	self._targetArrow.CFrame = CFrame.lookAt(origin, origin + targetVector)
-	self._targetArrow.Length = LENGTH
+        local worldTargetCF = CFrame.lookAt(origin, origin + targetVector)
+        self._targetArrow.CFrame = self._root.CFrame:ToObjectSpace(worldTargetCF)
+        self._targetArrow.Length = LENGTH
 
        local angle = math.deg(math.acos(math.clamp(upVector:Dot(targetVector), -1, 1)))
        self._label.Text = string.format("|u| %.2f\n∠ %.2f", upVector.Magnitude, angle)

--- a/src/client/Wallstick/Debug/GravityVisualizer.luau
+++ b/src/client/Wallstick/Debug/GravityVisualizer.luau
@@ -87,8 +87,8 @@ function GravityVisualizer:_update()
 	self._targetArrow.CFrame = CFrame.lookAt(origin, origin + targetVector)
 	self._targetArrow.Length = LENGTH
 
-	local angle = math.deg(math.acos(math.clamp(upVector:Dot(targetVector), -1, 1)))
-	self._label.Text = string.format("|u| %.2f\n\u2220 %.2f", upVector.Magnitude, angle)
+       local angle = math.deg(math.acos(math.clamp(upVector:Dot(targetVector), -1, 1)))
+       self._label.Text = string.format("|u| %.2f\n∠ %.2f", upVector.Magnitude, angle)
 end
 
 function GravityVisualizer:Destroy()

--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -27,6 +27,7 @@ local SharedPackages = ReplicatedStorage.SharedPackages
 local RaycastHelper = require(SharedPackages.RaycastHelper)
 local WallstickClass = require(ReplicatedStorage.Wallstick)
 local Replication = require(ReplicatedStorage.Wallstick.Replication)
+local GravityVisualizer = require(ReplicatedStorage.Wallstick.Debug.GravityVisualizer)
 
 -- Excludes parts belonging to player's limbs and accessories
 local function ignoreCharacterParts(result: RaycastResult): boolean
@@ -111,3 +112,6 @@ end
 localPlayer.CharacterAdded:Connect(onCharacterAdded)
 
 Replication.listenClient()
+
+-- Initialize Studio-only gravity visualizer
+local _debugVisualizer = GravityVisualizer.new()


### PR DESCRIPTION
## Summary
- create `DebugDraw` helper for arrows with z-index offset and TTL cleanup
- use `DebugDraw` inside `GravityVisualizer`
- document debug utilities in AGENTS

## Testing
- `selene --version` *(fails: command not found)*
- `luau-lsp --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688035dd1e3c8325993dec31b9626c7f