### PR TITLE
Simplify gravity camera move vector

### DIFF
--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -60,8 +60,8 @@ function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vec
        -- Project camera look vector onto the plane defined by the camera's up vector
        local forward = (cameraCF.LookVector - cameraCF.UpVector * cameraCF.LookVector:Dot(cameraCF.UpVector)).Unit
 
-       -- Right vector is orthogonal to both up and forward
-       local right = cameraCF.UpVector:Cross(forward)
+       -- Right vector is orthogonal to both forward and up
+       local right = forward:Cross(cameraCF.UpVector)
 
        -- Combine right/forward basis with input move vector
        return right * moveVector.X + forward * moveVector.Z

--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -56,19 +56,24 @@ end
 function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vector3
 	local moveVector = inputMove or controlModuleObject:GetMoveVector() :: Vector3
 
-	-- Raw movement relative to camera
-	local moveDirection = cameraCF.RightVector * moveVector.X - cameraCF.LookVector * moveVector.Z
+	local up = cameraCF.UpVector
+	local look = cameraCF.LookVector
+	local right = cameraCF.RightVector
 
-	-- Project movement onto surface plane (orthogonal to gravity)
-	local gravityUp = cameraCF.UpVector
-	local projected = moveDirection - gravityUp * moveDirection:Dot(gravityUp)
-
-	-- Normalize direction and scale by input magnitude
-	if projected.Magnitude > 0 then
-		return projected.Unit * moveDirection.Magnitude
-	else
-		return Vector3.zero
+	-- Prevent look vector from becoming nearly vertical (dot near +/-1)
+	local dot = math.abs(look:Dot(up))
+	if dot > 0.95 then
+		-- Clamp by forcing a horizontal look vector using camera rotation around up
+		look = (CFrame.fromMatrix(Vector3.zero, right:Cross(up), up, right)).LookVector
 	end
+
+	-- Construct move direction in local space
+	local moveDirection = right * moveVector.X - look * moveVector.Z
+
+	-- Project onto gravity plane
+	local projected = moveDirection - up * moveDirection:Dot(up)
+
+	return if projected.Magnitude > 0 then projected.Unit * moveDirection.Magnitude else Vector3.zero
 end
 
 return GravityCamera

--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -53,21 +53,22 @@ function GravityCamera.getRotationType(): Enum.RotationType
 	return cameraModuleObject:GetRotationType()
 end
 
--- stylua: ignore
 function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vector3
-       local moveVector = inputMove or controlModuleObject:GetMoveVector() :: Vector3
+	local moveVector = inputMove or controlModuleObject:GetMoveVector() :: Vector3
 
-       -- Safely project LookVector onto the UpVector plane
-       local rawForward = cameraCF.LookVector - cameraCF.UpVector * cameraCF.LookVector:Dot(cameraCF.UpVector)
-       local forward = if rawForward.Magnitude > 0 then rawForward.Unit else Vector3.zero
+	-- Raw movement relative to camera
+	local moveDirection = cameraCF.RightVector * moveVector.X - cameraCF.LookVector * moveVector.Z
 
-       -- Right vector is tangent and orthogonal
-       local right = forward:Cross(cameraCF.UpVector)
+	-- Project movement onto surface plane (orthogonal to gravity)
+	local gravityUp = cameraCF.UpVector
+	local projected = moveDirection - gravityUp * moveDirection:Dot(gravityUp)
 
-       -- Recalculate forward if it became Vector3.zero
-       local adjustedForward = if forward.Magnitude > 0 then forward else cameraCF.UpVector:Cross(right)
-
-       return right * moveVector.X - adjustedForward * moveVector.Z
+	-- Normalize direction and scale by input magnitude
+	if projected.Magnitude > 0 then
+		return projected.Unit * moveDirection.Magnitude
+	else
+		return Vector3.zero
+	end
 end
 
 return GravityCamera

--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -58,13 +58,18 @@ function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vec
 
 	local up = cameraCF.UpVector
 
-	-- Get the camera's flat (yaw-only) rotation
-	local flatCamera = CFrame.lookAt(Vector3.zero, Vector3.new(cameraCF.LookVector.X, 0, cameraCF.LookVector.Z))
-	local yawForward = (flatCamera.LookVector - up * flatCamera.LookVector:Dot(up)).Unit
-	local yawRight = yawForward:Cross(up)
+	-- Get camera heading vector by removing pitch (flatten LookVector)
+	local lookFlat = Vector3.new(cameraCF.LookVector.X, 0, cameraCF.LookVector.Z)
+	if lookFlat.Magnitude < 0.01 then
+		-- Edge case: camera is pointing straight up/down → default to a safe forward
+		lookFlat = Vector3.zAxis
+	end
 
-	-- Use yaw-aligned movement basis
-	local moveDirection = yawRight * moveVector.X - yawForward * moveVector.Z
+	-- Build a custom surface-relative frame
+	local forward = (lookFlat - up * lookFlat:Dot(up)).Unit
+	local right = up:Cross(forward)
+
+	local moveDirection = right * moveVector.X + forward * moveVector.Z
 
 	return if moveDirection.Magnitude > 0 then moveDirection.Unit * moveVector.Magnitude else Vector3.zero
 end

--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -33,6 +33,11 @@ local controlModuleObject = playerModuleObject:GetControls() :: any
 
 local GravityCamera = {}
 
+-- When the camera is looking straight up/down, the planar forward collapses.
+-- Cache the last good one so movement never stalls.
+local lastPlanarForward: Vector3 = Vector3.zAxis
+local EPS = 1e-4
+
 function GravityCamera.getUpVector(): Vector3
 	return cameraModuleObject:GetUpVector()
 end
@@ -55,22 +60,43 @@ end
 
 function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vector3
 	local moveVector = inputMove or controlModuleObject:GetMoveVector() :: Vector3
+
+	-- Gravity up for the current camera (i.e., local surface normal)
 	local up = cameraCF.UpVector
 
-	-- Get yaw-only LookVector by flattening onto XZ and projecting onto gravity plane
-	local flatLook = Vector3.new(cameraCF.LookVector.X, 0, cameraCF.LookVector.Z)
-	if flatLook.Magnitude < 1e-4 then
-		flatLook = Vector3.zAxis -- Fallback for looking straight up/down
+	-- 1) Remove pitch: take the camera's look, strip the component along 'up'
+	--    This gives us the yaw-only heading on the gravity plane.
+	local flattened = cameraCF.LookVector - up * cameraCF.LookVector:Dot(up)
+
+	local forward: Vector3
+	if flattened.Magnitude > EPS then
+		forward = flattened.Unit
+		lastPlanarForward = forward
+	else
+		-- Camera is (nearly) parallel to 'up' → reuse last stable forward so we don't stall.
+		forward = lastPlanarForward
 	end
 
-	-- Project onto gravity-defined surface plane
-	local forward = (flatLook - up * flatLook:Dot(up)).Unit
-	local right = forward:Cross(up) -- Correct handedness for A/D
+	-- 2) Build a right vector that’s tangent and with the correct handedness for Roblox WASD
+	--    (A = left, D = right). Using forward:Cross(up) keeps A/D correct.
+	local right = forward:Cross(up)
+	if right.Magnitude <= EPS then
+		-- Super edge case: if this ever collapses, rebuild from cached forward.
+		right = lastPlanarForward:Cross(up)
+	end
+	right = right.Unit
 
-	-- Roblox input: Z+ is back (S), Z– is forward (W), so we negate forward
+	-- 3) Map WASD:
+	--    - Roblox moveVector.Z: +1 is S (back), -1 is W (forward)
+	--    - So we subtract forward * Z to keep W = forward
 	local moveDirection = right * moveVector.X - forward * moveVector.Z
 
-	return if moveDirection.Magnitude > 0 then moveDirection.Unit * moveVector.Magnitude else Vector3.zero
+	-- Always return a direction with consistent magnitude relative to the input,
+	-- never the (possibly shrunken) projected vector's magnitude.
+	if moveDirection.Magnitude > 0 then
+		return moveDirection.Unit * moveVector.Magnitude
+	end
+	return Vector3.zero
 end
 
 return GravityCamera

--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -55,40 +55,16 @@ end
 
 -- stylua: ignore
 function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vector3
-	local moveVector = inputMove or controlModuleObject:GetMoveVector() :: Vector3
+       local moveVector = inputMove or controlModuleObject:GetMoveVector() :: Vector3
 
-	-- Extract rotation matrix components from camera's CFrame
-	local _, _, _, 
-		rightX, rightY, rightZ, -- Right vector
-		_, upY, upZ, -- Up vector (partial)
-		_, _, lookZ -- Look vector (partial)
-		= cameraCF:GetComponents()
+       -- Project camera look vector onto the plane defined by the camera's up vector
+       local forward = (cameraCF.LookVector - cameraCF.UpVector * cameraCF.LookVector:Dot(cameraCF.UpVector)).Unit
 
-	-- Determine quadrant flip based on upY sign (typically 1 or -1)
-	local quadrantSign = math.sign(upY)
+       -- Right vector is orthogonal to both up and forward
+       local right = cameraCF.UpVector:Cross(forward)
 
-	-- Choose basis vectors based on camera tilt, protecting against gimbal lock when looking straight up/down (upZ = ±1)
-	local cameraRight, cameraForward
-	if upZ > -1 and upZ < 1 then
-		-- Normal orientation: use camera's forward and right
-		cameraForward = lookZ  -- Z axis
-		cameraRight = rightZ   -- X axis, but projected
-	else
-		-- Extreme tilt: fallback to horizontal plane projection
-		cameraForward = rightX
-		cameraRight = -rightY * math.sign(upZ)
-	end
-
-	-- Normalize combined influence of forward and right axes
-	local magnitude = math.sqrt(cameraForward * cameraForward + cameraRight * cameraRight)
-	local normForward = cameraForward / magnitude
-	local normRight = cameraRight / magnitude
-
-	-- Project input move direction onto custom basis
-	local worldX = (normForward * moveVector.X * quadrantSign + normRight * moveVector.Z)
-	local worldZ = (normForward * moveVector.Z - normRight * moveVector.X * quadrantSign)
-
-	return Vector3.new(worldX, 0, worldZ)
+       -- Combine right/forward basis with input move vector
+       return right * moveVector.X + forward * moveVector.Z
 end
 
 return GravityCamera

--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -64,7 +64,8 @@ function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vec
        local right = forward:Cross(cameraCF.UpVector)
 
        -- Combine right/forward basis with input move vector
-       return right * moveVector.X + forward * moveVector.Z
+       -- moveVector.Z is positive when moving backward, so subtract it
+       return right * moveVector.X - forward * moveVector.Z
 end
 
 return GravityCamera

--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -57,14 +57,16 @@ end
 function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vector3
        local moveVector = inputMove or controlModuleObject:GetMoveVector() :: Vector3
 
-       -- Project camera look vector onto the plane defined by the camera's up vector
-       local forward = (cameraCF.LookVector - cameraCF.UpVector * cameraCF.LookVector:Dot(cameraCF.UpVector)).Unit
+       -- Project LookVector onto the UpVector plane
+       local rawForward = cameraCF.LookVector - cameraCF.UpVector * cameraCF.LookVector:Dot(cameraCF.UpVector)
 
-       -- Right vector is orthogonal to both forward and up
+       -- Fallback if projection is too small (e.g., looking straight up/down)
+       local forward = if rawForward.Magnitude > 0.001
+               then rawForward.Unit
+               else cameraCF.RightVector:Cross(cameraCF.UpVector)
+
        local right = forward:Cross(cameraCF.UpVector)
 
-       -- Combine right/forward basis with input move vector
-       -- moveVector.Z is positive when moving backward, so subtract it
        return right * moveVector.X - forward * moveVector.Z
 end
 

--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -57,17 +57,17 @@ end
 function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vector3
        local moveVector = inputMove or controlModuleObject:GetMoveVector() :: Vector3
 
-       -- Project LookVector onto the UpVector plane
+       -- Safely project LookVector onto the UpVector plane
        local rawForward = cameraCF.LookVector - cameraCF.UpVector * cameraCF.LookVector:Dot(cameraCF.UpVector)
+       local forward = if rawForward.Magnitude > 0 then rawForward.Unit else Vector3.zero
 
-       -- Fallback if projection is too small (e.g., looking straight up/down)
-       local forward = if rawForward.Magnitude > 0.001
-               then rawForward.Unit
-               else cameraCF.RightVector:Cross(cameraCF.UpVector)
-
+       -- Right vector is tangent and orthogonal
        local right = forward:Cross(cameraCF.UpVector)
 
-       return right * moveVector.X - forward * moveVector.Z
+       -- Recalculate forward if it became Vector3.zero
+       local adjustedForward = if forward.Magnitude > 0 then forward else cameraCF.UpVector:Cross(right)
+
+       return right * moveVector.X - adjustedForward * moveVector.Z
 end
 
 return GravityCamera

--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -57,23 +57,16 @@ function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vec
 	local moveVector = inputMove or controlModuleObject:GetMoveVector() :: Vector3
 
 	local up = cameraCF.UpVector
-	local look = cameraCF.LookVector
-	local right = cameraCF.RightVector
 
-	-- Prevent look vector from becoming nearly vertical (dot near +/-1)
-	local dot = math.abs(look:Dot(up))
-	if dot > 0.95 then
-		-- Clamp by forcing a horizontal look vector using camera rotation around up
-		look = (CFrame.fromMatrix(Vector3.zero, right:Cross(up), up, right)).LookVector
-	end
+	-- Get the camera's flat (yaw-only) rotation
+	local flatCamera = CFrame.lookAt(Vector3.zero, Vector3.new(cameraCF.LookVector.X, 0, cameraCF.LookVector.Z))
+	local yawForward = (flatCamera.LookVector - up * flatCamera.LookVector:Dot(up)).Unit
+	local yawRight = yawForward:Cross(up)
 
-	-- Construct move direction in local space
-	local moveDirection = right * moveVector.X - look * moveVector.Z
+	-- Use yaw-aligned movement basis
+	local moveDirection = yawRight * moveVector.X - yawForward * moveVector.Z
 
-	-- Project onto gravity plane
-	local projected = moveDirection - up * moveDirection:Dot(up)
-
-	return if projected.Magnitude > 0 then projected.Unit * moveDirection.Magnitude else Vector3.zero
+	return if moveDirection.Magnitude > 0 then moveDirection.Unit * moveVector.Magnitude else Vector3.zero
 end
 
 return GravityCamera

--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -55,21 +55,20 @@ end
 
 function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vector3
 	local moveVector = inputMove or controlModuleObject:GetMoveVector() :: Vector3
-
 	local up = cameraCF.UpVector
 
-	-- Get camera heading vector by removing pitch (flatten LookVector)
-	local lookFlat = Vector3.new(cameraCF.LookVector.X, 0, cameraCF.LookVector.Z)
-	if lookFlat.Magnitude < 0.01 then
-		-- Edge case: camera is pointing straight up/down → default to a safe forward
-		lookFlat = Vector3.zAxis
+	-- Get yaw-only LookVector by flattening onto XZ and projecting onto gravity plane
+	local flatLook = Vector3.new(cameraCF.LookVector.X, 0, cameraCF.LookVector.Z)
+	if flatLook.Magnitude < 1e-4 then
+		flatLook = Vector3.zAxis -- Fallback for looking straight up/down
 	end
 
-	-- Build a custom surface-relative frame
-	local forward = (lookFlat - up * lookFlat:Dot(up)).Unit
-	local right = up:Cross(forward)
+	-- Project onto gravity-defined surface plane
+	local forward = (flatLook - up * flatLook:Dot(up)).Unit
+	local right = forward:Cross(up) -- Correct handedness for A/D
 
-	local moveDirection = right * moveVector.X + forward * moveVector.Z
+	-- Roblox input: Z+ is back (S), Z– is forward (W), so we negate forward
+	local moveDirection = right * moveVector.X - forward * moveVector.Z
 
 	return if moveDirection.Magnitude > 0 then moveDirection.Unit * moveVector.Magnitude else Vector3.zero
 end


### PR DESCRIPTION
## Summary
- simplify GravityCamera.getMoveVector by projecting LookVector onto the up vector plane
- compute right vector via cross product

## Testing
- `stylua src/client/Wallstick/GravityCamera.luau`
- `selene src/client/Wallstick/GravityCamera.luau` *(fails: Could not collect standard library)*

------
https://chatgpt.com/codex/tasks/task_e_68818c00a06083258bac6c191e33ea14