### PR TITLE
Switch to GetPartBoundsInBox in collision update

### DIFF
--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -197,11 +197,16 @@ function WallstickClass._updateCollisionGeometry(self: Wallstick)
 
 	local colliderBoxSizeHalf = Vector3.new(10, 10, 10)
 
-	local parts = workspace:FindPartsInRegion3WithIgnoreList(
-		Region3.new(realRootCF.Position - colliderBoxSizeHalf, realRootCF.Position + colliderBoxSizeHalf),
-		{ self.real.character, self.options.parent } :: { Instance },
-		1000
-	) :: { BasePart }
+	local regionMin = realRootCF.Position - colliderBoxSizeHalf
+	local regionMax = realRootCF.Position + colliderBoxSizeHalf
+	local center = (regionMin + regionMax) / 2
+	local size = regionMax - regionMin
+
+	local params = OverlapParams.new()
+	params.FilterType = Enum.RaycastFilterType.Blacklist
+	params.FilterDescendantsInstances = { self.real.character, self.options.parent } :: { Instance }
+
+	local parts = workspace:GetPartBoundsInBox(CFrame.new(center), size, params) :: { BasePart }
 
 	for _, realPart in parts do
 		local collisionPart: BasePart


### PR DESCRIPTION
## Summary
- modernize collision detection in Wallstick by replacing `FindPartsInRegion3WithIgnoreList`
- use `GetPartBoundsInBox` with `OverlapParams`

## Testing
- `stylua src/client/Wallstick/init.luau`
- `selene src/client/Wallstick/init.luau` *(fails: Could not collect standard library)*

------
https://chatgpt.com/codex/tasks/task_e_6884990264588325aae999b616b09145